### PR TITLE
Add GitHub Action to auto comment on new issues

### DIFF
--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,33 @@
+name: Issue Auto Reply
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const message = `
+            👋 **Thank you for raising this issue!**  
+            Our team will review it soon.  
+
+            💬 For queries, discussions, or approval of requests, please join our Discord server:  
+            👉 [Discord Link](https://discord.com/invite/Yn9g6KuWyA)
+            `;
+
+            await github.rest.issues.createComment({
+              issue_number: issueNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });


### PR DESCRIPTION
Resolves #4 
This PR adds a GitHub Actions workflow that automatically comments on newly opened issues with a welcome message and a link to the Discord server for further discussion.

Key points:

Trigger: on new issue creation

Uses actions/github-script

Posts a friendly welcome message with Discord link